### PR TITLE
multi: More robust handling of server crashes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -147,7 +147,7 @@ Metrics/CollectionLiteralLength:
 Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/MethodLength:
-  Max: 30
+  Max: 35
 Metrics/ModuleLength:
   Max: 500
 Metrics/ParameterLists:
@@ -334,6 +334,9 @@ Style/RedundantSelfAssignmentBranch:
   Enabled: true
 Style/RedundantStringEscape:
   Enabled: true
+Style/RescueModifier:
+  Exclude:
+    - "test/**/*"
 Style/ReturnNilInPredicateMethodDefinition:
   Enabled: false
 Style/SafeNavigationChainLength:

--- a/README.md
+++ b/README.md
@@ -183,9 +183,6 @@ wrapper.join
     later unless they are configured to run "in place". In particular,
     using blocks as a syntax to define callbacks can generally not be done
     through a wrapper.
-*   Wrappers do basic detection of unexpected issues and attempt to clean up,
-    but it's still possible that a hard crash of a wrapper could leave callers
-    hanging. See https://github.com/dazuma/ractor-wrapper/issues/8
 
 ## Contributing
 

--- a/lib/ractor/wrapper.rb
+++ b/lib/ractor/wrapper.rb
@@ -174,6 +174,22 @@ class Ractor
   #
   class Wrapper
     ##
+    # Base class for errors raised by {Ractor::Wrapper}.
+    #
+    class Error < ::Ractor::Error; end
+
+    ##
+    # Raised when a {Ractor::Wrapper} server has crashed unexpectedly.
+    #
+    class CrashedError < Error; end
+
+    ##
+    # Raised when calling a method on a {Ractor::Wrapper} whose server has
+    # stopped and is no longer accepting calls.
+    #
+    class StoppedError < Error; end
+
+    ##
     # A stub that forwards calls to a wrapper.
     #
     # This object is shareable and can be passed to any Ractor.
@@ -578,7 +594,11 @@ class Ractor
                                 settings: settings,
                                 reply_port: reply_port)
       maybe_log("Sending method", method_name: method_name, transaction: transaction)
-      @port.send(message, move: settings.move_arguments?)
+      begin
+        @port.send(message, move: settings.move_arguments?)
+      rescue ::Ractor::ClosedError
+        raise StoppedError, "Wrapper has stopped"
+      end
       loop do
         reply_message = reply_port.receive
         case reply_message
@@ -586,14 +606,14 @@ class Ractor
           handle_yield(reply_message, transaction, settings, method_name, &)
         when ReturnMessage
           maybe_log("Received result", method_name: method_name, transaction: transaction)
-          reply_port.close
           return reply_message.value
         when ExceptionMessage
           maybe_log("Received exception", method_name: method_name, transaction: transaction)
-          reply_port.close
           raise reply_message.exception
         end
       end
+    ensure
+      reply_port.close
     end
 
     ##
@@ -617,6 +637,10 @@ class Ractor
     ##
     # Blocks until the wrapper has fully stopped.
     #
+    # Unlike `Thread#join` and `Ractor#join`, if a Wrapper crashes, the
+    # exception generally does *not* get raised out of `Wrapper#join`. Instead,
+    # it just returns self in the same way as normal termination.
+    #
     # @return [self]
     #
     def join
@@ -624,12 +648,15 @@ class Ractor
         @ractor.join
       else
         reply_port = ::Ractor::Port.new
-        @port.send(JoinMessage.new(reply_port))
-        reply_port.receive
-        reply_port.close
+        begin
+          @port.send(JoinMessage.new(reply_port))
+          reply_port.receive
+        rescue ::Ractor::ClosedError
+          # Assume the wrapper has stopped if the port is not sendable
+        ensure
+          reply_port.close
+        end
       end
-      self
-    rescue ::Ractor::ClosedError
       self
     end
 
@@ -688,6 +715,12 @@ class Ractor
 
     ##
     # @private
+    # Message sent from a server in response to a join request.
+    #
+    JoinReplyMessage = ::Data.define
+
+    ##
+    # @private
     # Message sent to report a return value
     #
     ReturnMessage = ::Data.define(:value)
@@ -714,7 +747,9 @@ class Ractor
       maybe_log("Starting local server")
       @ractor = nil
       @port = ::Ractor::Port.new
+      wrapper_id = object_id
       ::Thread.new do
+        ::Thread.current.name = "ractor-wrapper:server:#{wrapper_id}"
         Server.run_local(object: object,
                          port: @port,
                          name: name,
@@ -834,8 +869,7 @@ class Ractor
         @port = port
         @name = name
         @enable_logging = enable_logging
-        @threading_enabled = threads.positive?
-        @active_workers = threads
+        @threads_requested = threads.positive? ? threads : false
         @join_requests = []
       end
 
@@ -847,14 +881,16 @@ class Ractor
       #
       def run
         receive_remote_object if @isolated
-        start_workers if @threading_enabled
+        start_workers if @threads_requested
         main_loop
-        stop_workers if @threading_enabled
+        stop_workers if @threads_requested
         cleanup
         @object
-      rescue ::StandardError => e
-        maybe_log("Unexpected error: #{e.inspect}")
+      rescue ::Exception => e # rubocop:disable Lint/RescueException
+        @crash_exception = e
         @object
+      ensure
+        crash_cleanup if @crash_exception
       end
 
       private
@@ -873,10 +909,11 @@ class Ractor
       # shared queue. Called only if worker threading is enabled.
       #
       def start_workers
+        maybe_log("Spawning #{@threads_requested} worker threads")
         @queue = ::Queue.new
-        maybe_log("Spawning #{@active_workers} worker threads")
-        (1..@active_workers).map do |worker_num|
-          ::Thread.new { worker_thread(worker_num) }
+        @active_workers = {}
+        (1..@threads_requested).each do |worker_num|
+          @active_workers[worker_num] = ::Thread.new { worker_thread(worker_num) }
         end
       end
 
@@ -902,14 +939,14 @@ class Ractor
           case message
           when CallMessage
             maybe_log("Received CallMessage", call_message: message)
-            if @threading_enabled
+            if @threads_requested
               @queue.enq(message)
             else
               handle_method(message)
             end
           when WorkerStoppedMessage
             maybe_log("Received unexpected WorkerStoppedMessage")
-            @active_workers -= 1 if @threading_enabled
+            @active_workers.delete(message.worker_num) if @threads_requested
             break
           when StopMessage
             maybe_log("Received stop")
@@ -944,7 +981,7 @@ class Ractor
       #
       def stop_workers
         @queue.close
-        while @active_workers.positive?
+        until @active_workers.empty?
           maybe_log("Waiting for message in stopping phase")
           message = @port.receive
           case message
@@ -952,7 +989,7 @@ class Ractor
             refuse_method(message)
           when WorkerStoppedMessage
             maybe_log("Acknowledged WorkerStoppedMessage: #{message.worker_num}")
-            @active_workers -= 1
+            @active_workers.delete(message.worker_num)
           when StopMessage
             maybe_log("Stop received when already stopping")
           when JoinMessage
@@ -969,8 +1006,6 @@ class Ractor
       def cleanup
         maybe_log("Closing inbox")
         @port.close
-        maybe_log("Responding to join requests")
-        @join_requests.each { |port| send_join_reply(port) }
         maybe_log("Draining inbox")
         loop do
           message = begin
@@ -991,6 +1026,94 @@ class Ractor
             maybe_log("Received and responding immediately to join request")
             send_join_reply(message.reply_port)
           end
+        end
+        maybe_log("Responding to join requests")
+        @join_requests.each { |port| send_join_reply(port) }
+      end
+
+      ##
+      # Called from the ensure block in run when an unexpected exception
+      # terminated the server. Drains pending requests that are not otherwise
+      # being handled, responding to all pending callers and join requesters,
+      # and also joins any worker threads.
+      #
+      def crash_cleanup
+        maybe_log("Running crash cleanup after: #{@crash_exception.message} (#{@crash_exception.class})")
+        error = CrashedError.new("Server crashed: #{@crash_exception.message} (#{@crash_exception.class})")
+        # `@queue` should not be nil in threaded mode, but we're checking
+        # anyway just in case a crash happened during setup
+        drain_queue_after_crash(@queue, error) if @threads_requested && @queue
+        drain_inbox_after_crash(@port, error)
+        # `@active_workers` should not be nil in threaded mode, but we're
+        # checking anyway just in case a crash happened during setup
+        join_workers_after_crash(@active_workers) if @threads_requested && @active_workers
+        @join_requests.each { |port| send_join_reply(port) }
+      rescue ::Exception => e # rubocop:disable Lint/RescueException
+        maybe_log("Suppressed exception during crash_cleanup: #{e.message} (#{e.class})")
+      end
+
+      ##
+      # Drains any remaining queued call messages after a crash, sending errors
+      # to callers whose calls had not yet been dispatched to a worker thread.
+      #
+      def drain_queue_after_crash(queue, error)
+        queue.close
+        loop do
+          message = queue.deq
+          break if message.nil?
+          begin
+            message.reply_port.send(ExceptionMessage.new(error))
+          rescue ::Ractor::Error
+            maybe_log("Failed to send crash error to queued caller", call_message: message)
+          end
+        end
+      rescue ::Exception => e # rubocop:disable Lint/RescueException
+        maybe_log("Suppressed exception during drain_queue_after_crash: " \
+                  "#{e.message} (#{e.class})")
+      end
+
+      ##
+      # Drains any remaining inbox messages after a crash, sending errors to
+      # pending callers and responding to any join requests.
+      #
+      def drain_inbox_after_crash(port, error)
+        begin
+          port.close
+        rescue ::Ractor::Error
+          # Port was already closed (maybe because it was the cause of the crash)
+        end
+        loop do
+          message = begin
+            port.receive
+          rescue ::Ractor::Error
+            nil
+          end
+          break if message.nil?
+          case message
+          when CallMessage
+            begin
+              message.reply_port.send(ExceptionMessage.new(error))
+            rescue ::Ractor::Error
+              maybe_log("Failed to send crash error to caller", call_message: message)
+            end
+          when JoinMessage
+            send_join_reply(message.reply_port)
+          when WorkerStoppedMessage, StopMessage
+            # Ignore
+          end
+        end
+      rescue ::Exception => e # rubocop:disable Lint/RescueException
+        maybe_log("Suppressed exception during drain_inbox_after_crash: #{e.message} (#{e.class})")
+      end
+
+      ##
+      # Wait until all workers have stopped after a crash
+      #
+      def join_workers_after_crash(workers)
+        workers.each_value do |thread|
+          thread.join
+        rescue ::Exception => e # rubocop:disable Lint/RescueException
+          maybe_log("Suppressed exception during join_workers_after_crash: #{e.message} (#{e.class})")
         end
       end
 
@@ -1015,7 +1138,7 @@ class Ractor
         begin
           @port.send(WorkerStoppedMessage.new(worker_num))
         rescue ::Ractor::ClosedError
-          maybe_log("Orphaned worker thread", worker_num: worker_num)
+          maybe_log("Worker unable to report stop, possibly due to server crash", worker_num: worker_num)
         end
       end
 
@@ -1031,20 +1154,18 @@ class Ractor
       def handle_method(message, worker_num: nil)
         block = make_block(message)
         maybe_log("Running method", worker_num: worker_num, call_message: message)
+        result = @object.__send__(message.method_name, *message.args, **message.kwargs, &block)
+        maybe_log("Sending return value", worker_num: worker_num, call_message: message)
+        message.reply_port.send(ReturnMessage.new(result), move: message.settings.move_results?)
+      rescue ::Exception => e # rubocop:disable Lint/RescueException
+        maybe_log("Sending exception", worker_num: worker_num, call_message: message)
         begin
-          result = @object.__send__(message.method_name, *message.args, **message.kwargs, &block)
-          maybe_log("Sending return value", worker_num: worker_num, call_message: message)
-          message.reply_port.send(ReturnMessage.new(result), move: message.settings.move_results?)
-        rescue ::Exception => e # rubocop:disable Lint/RescueException
-          maybe_log("Sending exception", worker_num: worker_num, call_message: message)
+          message.reply_port.send(ExceptionMessage.new(e))
+        rescue ::Exception # rubocop:disable Lint/RescueException
           begin
-            message.reply_port.send(ExceptionMessage.new(e))
-          rescue ::StandardError
-            begin
-              message.reply_port.send(ExceptionMessage.new(::StandardError.new(e.inspect)))
-            rescue ::StandardError
-              maybe_log("Failure to send method response", worker_num: worker_num, call_message: message)
-            end
+            message.reply_port.send(ExceptionMessage.new(::RuntimeError.new(e.inspect)))
+          rescue ::Exception # rubocop:disable Lint/RescueException
+            maybe_log("Failure to send method response", worker_num: worker_num, call_message: message)
           end
         end
       end
@@ -1063,10 +1184,13 @@ class Ractor
         return message.block_arg unless message.block_arg == :send_block_message
         proc do |*args, **kwargs|
           reply_port = ::Ractor::Port.new
-          yield_message = YieldMessage.new(args: args, kwargs: kwargs, reply_port: reply_port)
-          message.reply_port.send(yield_message, move: message.settings.move_block_arguments?)
-          reply_message = reply_port.receive
-          reply_port.close
+          reply_message = begin
+            yield_message = YieldMessage.new(args: args, kwargs: kwargs, reply_port: reply_port)
+            message.reply_port.send(yield_message, move: message.settings.move_block_arguments?)
+            reply_port.receive
+          ensure
+            reply_port.close
+          end
           case reply_message
           when ExceptionMessage
             raise reply_message.exception
@@ -1084,7 +1208,7 @@ class Ractor
       def refuse_method(message)
         maybe_log("Refusing method call", call_message: message)
         begin
-          error = ::Ractor::ClosedError.new("Wrapper is shutting down")
+          error = StoppedError.new("Wrapper is shutting down")
           message.reply_port.send(ExceptionMessage.new(error))
         rescue ::Ractor::Error
           maybe_log("Failed to send refusal message", call_message: message)
@@ -1095,7 +1219,7 @@ class Ractor
       # This attempts to send a signal that a wrapper join has completed.
       #
       def send_join_reply(port)
-        port.send(nil)
+        port.send(JoinReplyMessage.new.freeze)
       rescue ::Ractor::ClosedError
         maybe_log("Join reply port is closed")
       end
@@ -1107,13 +1231,15 @@ class Ractor
         return unless @enable_logging
         transaction ||= call_message&.transaction
         method_name ||= call_message&.method_name
-        metadata = [::Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S.%L"), "Ractor::Wrapper/#{@name}"]
-        metadata << "Worker/#{worker_num}" if worker_num
-        metadata << "Transaction/#{transaction}" if transaction
-        metadata << "Method/#{method_name}" if method_name
+        metadata = [::Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S.%L"), "Ractor::Wrapper:#{@name}"]
+        metadata << "Worker:#{worker_num}" if worker_num
+        metadata << "Transaction:#{transaction}" if transaction
+        metadata << "Method:#{method_name}" if method_name
         metadata = metadata.join(" ")
         $stderr.puts("[#{metadata}] #{str}")
         $stderr.flush
+      rescue ::StandardError
+        # Swallow any errors during logging
       end
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,6 +5,20 @@ require "minitest/focus"
 require "minitest/rg"
 require "ractor/wrapper"
 
+# Create and throw away an initial Ractor, which will cause some versions of
+# Ruby to emit a warning. The intent is to trigger that warning early so it's
+# out of the way and does not interfere with test output later on.
+::Ractor.new {} # rubocop:disable Lint/EmptyBlock
+
+# A JoinMessage subclass used in tests to crash the isolated server: main_loop
+# accesses reply_port on the received message, and this override raises, causing
+# the exception to propagate out of main_loop and trigger crash cleanup.
+class CrashingJoinMessage < ::Ractor::Wrapper::JoinMessage
+  def reply_port
+    raise "simulated crash"
+  end
+end
+
 class RemoteObject
   def echo_args(*args, **kwargs)
     "#{args}, #{kwargs}"

--- a/test/test_wrapper.rb
+++ b/test/test_wrapper.rb
@@ -1,45 +1,68 @@
 # frozen_string_literal: true
 
 require "helper"
+require "timeout"
 
 describe ::Ractor::Wrapper do
   let(:remote) { RemoteObject.new }
+
+  describe "error classes" do
+    it "Error is a subclass of Ractor::Error" do
+      assert(::Ractor::Wrapper::Error < ::Ractor::Error)
+    end
+
+    it "CrashedError is a subclass of Error" do
+      assert(::Ractor::Wrapper::CrashedError < ::Ractor::Wrapper::Error)
+    end
+
+    it "StoppedError is a subclass of Error" do
+      assert(::Ractor::Wrapper::StoppedError < ::Ractor::Wrapper::Error)
+    end
+
+    it "CrashedError can be rescued as Ractor::Wrapper::Error" do
+      assert_raises(::Ractor::Wrapper::Error) { raise ::Ractor::Wrapper::CrashedError, "test" }
+    end
+
+    it "StoppedError can be rescued as Ractor::Wrapper::Error" do
+      assert_raises(::Ractor::Wrapper::Error) { raise ::Ractor::Wrapper::StoppedError, "test" }
+    end
+  end
 
   describe "initialization block" do
     after { @wrapper&.async_stop&.join }
 
     it "yields a Configuration, not the Wrapper itself" do
       yielded = nil
-      @wrapper = Ractor::Wrapper.new(remote) { |config| yielded = config }
-      assert_instance_of(Ractor::Wrapper::Configuration, yielded)
+      @wrapper = ::Ractor::Wrapper.new(remote) { |config| yielded = config }
+      assert_instance_of(::Ractor::Wrapper::Configuration, yielded)
       refute_equal(@wrapper, yielded)
     end
 
     it "can set name in the block" do
-      @wrapper = Ractor::Wrapper.new(remote) { |config| config.name = "myname" }
+      @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.name = "myname" }
       assert_equal("myname", @wrapper.name)
     end
 
     it "can set threads in the block" do
-      @wrapper = Ractor::Wrapper.new(remote) { |config| config.threads = 2 }
+      @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.threads = 2 }
       assert_equal(2, @wrapper.threads)
     end
 
     it "can set use_current_ractor in the block" do
-      @wrapper = Ractor::Wrapper.new(remote) { |config| config.use_current_ractor = true }
+      @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.use_current_ractor = true }
       assert(@wrapper.use_current_ractor?)
     end
 
     it "block settings override kwargs" do
-      @wrapper = Ractor::Wrapper.new(remote, threads: 2) { |config| config.threads = 0 }
+      @wrapper = ::Ractor::Wrapper.new(remote, threads: 2) { |config| config.threads = 0 }
       assert_equal(0, @wrapper.threads)
     end
 
     it "block can call configure_method" do
-      @wrapper = Ractor::Wrapper.new(remote) { |config| config.configure_method(move_arguments: true) }
+      @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.configure_method(move_arguments: true) }
       str = "hello".dup
       @wrapper.call(:echo_args, str)
-      assert_raises(Ractor::MovedError) { str.to_s }
+      assert_raises(::Ractor::MovedError) { str.to_s }
     end
   end
 
@@ -67,13 +90,13 @@ describe ::Ractor::Wrapper do
   threading_types.each do |config|
     describe "an isolated wrapper running #{config[:desc]}" do
       let(:base_opts) { config[:opts] }
-      let(:wrapper) { Ractor::Wrapper.new(remote, **base_opts) }
+      let(:wrapper) { ::Ractor::Wrapper.new(remote, **base_opts) }
 
       after { wrapper.async_stop.join }
 
       it "moves a wrapped object" do
         wrapper
-        assert_raises(Ractor::MovedError) do
+        assert_raises(::Ractor::MovedError) do
           remote.echo_args
         end
       end
@@ -81,7 +104,7 @@ describe ::Ractor::Wrapper do
       it "recovers the object" do
         assert_equal("[], {}", remote.echo_args)
         wrapper
-        assert_raises(Ractor::MovedError) do
+        assert_raises(::Ractor::MovedError) do
           remote.echo_args
         end
         wrapper.async_stop
@@ -92,7 +115,7 @@ describe ::Ractor::Wrapper do
 
     describe "a local wrapper" do
       let(:base_opts) { config[:opts] }
-      let(:wrapper) { Ractor::Wrapper.new(remote, **base_opts, use_current_ractor: true) }
+      let(:wrapper) { ::Ractor::Wrapper.new(remote, **base_opts, use_current_ractor: true) }
 
       after { wrapper.async_stop.join }
 
@@ -103,7 +126,7 @@ describe ::Ractor::Wrapper do
 
       it "refuses to recover" do
         wrapper.async_stop
-        error = assert_raises(Ractor::Error) do
+        error = assert_raises(::Ractor::Error) do
           wrapper.recover_object
         end
         assert_equal("cannot recover an object from a local wrapper", error.message)
@@ -119,19 +142,19 @@ describe ::Ractor::Wrapper do
       after { @wrapper&.async_stop&.join }
 
       it "refuses to wrap a moved object" do
-        port = Ractor::Port.new
+        port = ::Ractor::Port.new
         port.send(remote, move: true)
         port.receive
         port.close
-        error = assert_raises(Ractor::MovedError) do
-          Ractor::Wrapper.new(remote, **base_opts)
+        error = assert_raises(::Ractor::MovedError) do
+          ::Ractor::Wrapper.new(remote, **base_opts)
         end
         assert_equal("cannot wrap a moved object", error.message)
       end
 
       it "is shareable" do
-        @wrapper = Ractor::Wrapper.new(remote, **base_opts)
-        assert(Ractor.shareable?(@wrapper))
+        @wrapper = ::Ractor::Wrapper.new(remote, **base_opts)
+        assert(::Ractor.shareable?(@wrapper))
       end
     end
 
@@ -139,7 +162,7 @@ describe ::Ractor::Wrapper do
       let(:base_opts) { config1[:opts].merge(config2[:opts]) }
 
       def wrapper(**)
-        @wrapper ||= Ractor::Wrapper.new(remote, **base_opts, **)
+        @wrapper ||= ::Ractor::Wrapper.new(remote, **base_opts, **)
       end
 
       after { wrapper.async_stop.join }
@@ -150,7 +173,7 @@ describe ::Ractor::Wrapper do
       end
 
       it "gets exceptions" do
-        exception = assert_raises(RuntimeError) do
+        exception = assert_raises(::RuntimeError) do
           wrapper.call(:whoops)
         end
         assert_equal("Whoops", exception.message)
@@ -179,7 +202,7 @@ describe ::Ractor::Wrapper do
       let(:base_opts) { config1[:opts].merge(config2[:opts]) }
 
       def wrapper(**)
-        @wrapper ||= Ractor::Wrapper.new(remote, **base_opts, **)
+        @wrapper ||= ::Ractor::Wrapper.new(remote, **base_opts, **)
       end
 
       after { wrapper.async_stop.join }
@@ -194,14 +217,14 @@ describe ::Ractor::Wrapper do
         wrapper(move_arguments: true)
         str = "hello".dup
         wrapper.call(:echo_args, str)
-        assert_raises(Ractor::MovedError) { str.to_s }
+        assert_raises(::Ractor::MovedError) { str.to_s }
       end
 
       it "moves arguments when move_data is set to true" do
         wrapper(move_data: true)
         str = "hello".dup
         wrapper.call(:echo_args, str)
-        assert_raises(Ractor::MovedError) { str.to_s }
+        assert_raises(::Ractor::MovedError) { str.to_s }
       end
 
       it "honors move_arguments over move_data" do
@@ -302,9 +325,21 @@ describe ::Ractor::Wrapper do
       end
     end
 
+    describe "stopping behavior of #{config1[:desc]} running #{config2[:desc]}" do
+      let(:base_opts) { config1[:opts].merge(config2[:opts]) }
+      let(:wrapper) { ::Ractor::Wrapper.new(remote, **base_opts) }
+
+      after { wrapper.async_stop.join }
+
+      it "raises StoppedError when called after the wrapper has stopped" do
+        wrapper.async_stop.join
+        assert_raises(::Ractor::Wrapper::StoppedError) { wrapper.call(:echo_args) }
+      end
+    end
+
     describe "stubs in #{config1[:desc]} running #{config2[:desc]}" do
       let(:base_opts) { config1[:opts].merge(config2[:opts]) }
-      let(:wrapper) { Ractor::Wrapper.new(remote, **base_opts) }
+      let(:wrapper) { ::Ractor::Wrapper.new(remote, **base_opts) }
 
       after { wrapper.async_stop.join }
 
@@ -314,7 +349,7 @@ describe ::Ractor::Wrapper do
       end
 
       it "converts exceptions" do
-        exception = assert_raises(RuntimeError) do
+        exception = assert_raises(::RuntimeError) do
           wrapper.stub.whoops
         end
         assert_equal("Whoops", exception.message)
@@ -330,18 +365,36 @@ describe ::Ractor::Wrapper do
   wrapper_types.each do |config|
     describe "non-threaded lifecycle in #{config[:desc]}" do
       let(:base_opts) { config[:opts] }
-      let(:wrapper) { Ractor::Wrapper.new(remote, **base_opts) }
+      let(:wrapper) { ::Ractor::Wrapper.new(remote, **base_opts) }
 
       after { wrapper.async_stop.join }
 
-      it "serializes long-running methods" do
-        r1 = Ractor.new(wrapper) do |w|
-          result = w.call(:slow_echo, "hello")
-          [result, Time.now.to_f]
+      it "raises StoppedError when a call is refused during shutdown" do
+        ::Timeout.timeout(5) do
+          # Start a slow call so the server is occupied, then queue stop + another call.
+          # When the slow call finishes, server processes the stop, and cleanup refusees
+          # the queued call via refuse_method.
+          slow_thread = ::Thread.new { wrapper.call(:slow_echo, "fill") rescue nil }
+          sleep 0.1 # ensure slow call is being processed
+          wrapper.async_stop
+          result = begin
+            wrapper.call(:echo_args)
+          rescue ::StandardError => e
+            e
+          end
+          slow_thread.join
+          assert_instance_of(::Ractor::Wrapper::StoppedError, result)
         end
-        r2 = Ractor.new(wrapper) do |w|
+      end
+
+      it "serializes long-running methods" do
+        r1 = ::Ractor.new(wrapper) do |w|
+          result = w.call(:slow_echo, "hello")
+          [result, ::Time.now.to_f]
+        end
+        r2 = ::Ractor.new(wrapper) do |w|
           result = w.call(:slow_echo, "world")
-          [result, Time.now.to_f]
+          [result, ::Time.now.to_f]
         end
         result1, time1 = r1.value
         result2, time2 = r2.value
@@ -353,25 +406,128 @@ describe ::Ractor::Wrapper do
 
     describe "2-thread lifecycle in #{config[:desc]}" do
       let(:base_opts) { config[:opts] }
-      let(:wrapper) { Ractor::Wrapper.new(remote, **base_opts, threads: 2) }
+      let(:wrapper) { ::Ractor::Wrapper.new(remote, **base_opts, threads: 2) }
 
       after { wrapper.async_stop.join }
 
       it "parallelizes long-running methods" do
         wrapper.call(:echo_args, 1)
-        r1 = Ractor.new(wrapper) do |w|
+        r1 = ::Ractor.new(wrapper) do |w|
           result = w.call(:slow_echo, "hello")
-          [result, Time.now.to_f]
+          [result, ::Time.now.to_f]
         end
-        r2 = Ractor.new(wrapper) do |w|
+        r2 = ::Ractor.new(wrapper) do |w|
           result = w.call(:slow_echo, "world")
-          [result, Time.now.to_f]
+          [result, ::Time.now.to_f]
         end
         result1, time1 = r1.value
         result2, time2 = r2.value
         assert_equal("hello", result1)
         assert_equal("world", result2)
         assert_operator((time1 - time2).abs, :<, 0.8)
+      end
+    end
+  end
+
+  describe "after unexpected server termination" do
+    # Force a server crash by sending a CrashingJoinMessage (defined in
+    # helper.rb) to the server port. main_loop accesses reply_port on the
+    # received message, which raises, propagating out of main_loop and
+    # triggering the ensure-based crash cleanup.
+    def crash_server(wrapper)
+      wrapper.instance_variable_get(:@port).send(
+        CrashingJoinMessage.new(reply_port: nil),
+        move: true
+      )
+    end
+
+    [
+      {desc: "isolated threaded wrapper", opts: {threads: 1, enable_logging: true}},
+      {desc: "local threaded wrapper", opts: {use_current_ractor: true, threads: 1}},
+    ].each do |config|
+      describe config[:desc] do
+        it "notifies callers queued but not yet dispatched to a worker when the server crashes" do
+          ::Timeout.timeout(5) do
+            capture_subprocess_io do
+              wrapper = ::Ractor::Wrapper.new(remote, **config[:opts])
+              t1 = ::Thread.new { wrapper.call(:slow_echo, "first") rescue $! } # rubocop:disable Style/SpecialGlobalVars
+              sleep 0.1 # let the single worker pick up the first call
+              t2 = ::Thread.new { wrapper.call(:slow_echo, "second") rescue $! } # rubocop:disable Style/SpecialGlobalVars
+              sleep 0.1 # let the second call reach the queue
+              crash_server(wrapper)
+              result1 = t1.value
+              result2 = t2.value
+              # Call 1 was already dispatched to the worker, which finishes and replies normally
+              assert_equal("first", result1)
+              # Call 2 was queued but not dispatched; crash cleanup should notify it
+              assert_instance_of(::Ractor::Wrapper::CrashedError, result2)
+            end
+          end
+        end
+      end
+    end
+
+    [
+      {desc: "isolated sequential wrapper", opts: {}},
+      {desc: "isolated threaded wrapper", opts: {threads: 2}},
+      {desc: "local sequential wrapper", opts: {use_current_ractor: true}},
+      {desc: "local threaded wrapper", opts: {use_current_ractor: true, threads: 2}},
+    ].each do |config|
+      describe config[:desc] do
+        it "does not hang when the server crashes with a join pending" do
+          ::Timeout.timeout(5) do
+            capture_subprocess_io do
+              wrapper = ::Ractor::Wrapper.new(remote, **config[:opts])
+              join_thread = ::Thread.new { wrapper.join }
+              sleep 0.1  # let the join request reach and be queued by the server
+              crash_server(wrapper)
+              assert join_thread.join(5), "join should complete within 5 seconds"
+              assert_same(wrapper, join_thread.value)
+            end
+          end
+        end
+
+        it "does not hang when join called after the server has already crashed" do
+          ::Timeout.timeout(5) do
+            capture_subprocess_io do
+              wrapper = ::Ractor::Wrapper.new(remote, **config[:opts])
+              crash_server(wrapper)
+              sleep 0.1  # let crash cleanup finish and close the port
+              assert_same(wrapper, wrapper.join)
+            end
+          end
+        end
+
+        it "raises StoppedError if a call is made post-crash" do
+          ::Timeout.timeout(5) do
+            capture_subprocess_io do
+              wrapper = ::Ractor::Wrapper.new(remote, **config[:opts])
+              crash_server(wrapper)
+              sleep 0.1  # let crash cleanup finish and close the port
+              assert_raises(::Ractor::Wrapper::StoppedError) do
+                wrapper.call(:echo_args)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    [
+      {desc: "isolated sequential wrapper", opts: {}},
+      {desc: "isolated threaded wrapper", opts: {threads: 2}},
+    ].each do |config|
+      describe config[:desc] do
+        it "recovers the object" do
+          ::Timeout.timeout(5) do
+            capture_subprocess_io do
+              wrapper = ::Ractor::Wrapper.new(remote, **config[:opts])
+              crash_server(wrapper)
+              recovered = wrapper.recover_object
+              assert_equal("[], {}", recovered.echo_args)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
fix!: Raises `Ractor::Wrapper::StoppedError` instead of `Ractor::ClosedError` if a method is called via the wrapper after the wrapper has stopped
fix: Method calls raise `Ractor::Wrapper::CrashedError` instead of hanging if the wrapper crashes during handling
fix: `Wrapper#join` no longer hangs if a local wrapper crashes, but returns to indicate that the wrapper has stopped (albeit non-normally)
fix!: `Wrapper#join` now returns normally rather than raising, if an isolated wrapper terminated due to a crash
fix: Internal cleanup is more robust if a crash occurs in the wrapper
fix: Prevented port leaks if a method call send or a block yield send fails

Fixes #8