### PR TITLE
multi: Method communication configuration improvements

### DIFF
--- a/lib/ractor/wrapper.rb
+++ b/lib/ractor/wrapper.rb
@@ -273,47 +273,70 @@ class Ractor
       end
 
       ##
-      # Configure the move semantics for the given method (or the default
-      # settings if no method name is given.) That is, determine whether
-      # arguments, return values, and/or exceptions are copied or moved when
-      # communicated with the wrapper. By default, all objects are copied.
+      # Configure how argument and return values are communicated for the given
+      # method.
       #
-      # @param method_name [Symbol, nil] The name of the method being configured,
+      # In general, the following values are recognized for the data-moving
+      # settings:
+      #
+      # * `:copy` - Method arguments or return values that are not shareable,
+      #   are *deep copied* when communicated between the caller and the object.
+      # * `:move` - Method arguments or return values that are not shareable,
+      #   are *moved* when communicated between the caller and the object. This
+      #   means they are no longer available to the source; that is, the caller
+      #   can no longer access objects that were moved to method arguments, and
+      #   the wrapped object can no longer access objects that were used as
+      #   return values.
+      # * `:void` - This option is available for return values and block
+      #   results. It disables return values for the given method, and is
+      #   intended to avoid copying or moving objects that are not intended to
+      #   be return values. The recipient will receive `nil`.
+      #
+      # The following settings are recognized for the `block_environment`
+      # setting:
+      #
+      # * `:caller` - Blocks are executed in the caller's context. This means
+      #   the wrapper sends a message back to the caller to execute the block
+      #   in its original context. This means the block will have access to its
+      #   lexical scope and any other data available to the calling Ractor.
+      # * `:wrapped` - Blocks are executed directly in the wrapped object's
+      #   context. This does not require any communication, but it means the
+      #   block is removed from the caller's environment and does not have
+      #   access to the caller's lexical scope or Ractor-accessible data.
+      #
+      # All settings are optional. If not provided, they will fall back to a
+      # default. If you are configuring a particular method, by specifying the
+      # `method_name` argument, any unspecified setting will fall back to the
+      # method default settings (which you can set by omitting the method name.)
+      # If you are configuring the method default settings, by omitting the
+      # `method_name` argument, unspecified settings will fall back to `:copy`
+      # for the data movement settings, and `:caller` for the
+      # `block_environment` setting.
+      #
+      # @param method_name [Symbol,nil] The name of the method being configured,
       #     or `nil` to set defaults for all methods not configured explicitly.
-      # @param move_data [boolean] If true, communication for this method will
-      #     move instead of copy arguments and return values. Default is false.
-      #     This setting can be overridden by other `:move_*` settings.
-      # @param move_arguments [boolean] If true, arguments for this method are
-      #     moved instead of copied. If not set, uses the `:move_data` setting.
-      # @param move_results [boolean] If true, return values for this method are
-      #     moved instead of copied. If not set, uses the `:move_data` setting.
-      # @param move_block_arguments [boolean] If true, arguments to blocks passed
-      #     to this method are moved instead of copied. If not set, uses the
-      #     `:move_data` setting.
-      # @param move_block_results [boolean] If true, result values from blocks
-      #     passed to this method are moved instead of copied. If not set, uses
-      #     the `:move_data` setting.
-      # @param execute_blocks_in_place [boolean] If true, blocks passed to this
-      #     method are made shareable and passed into the wrapper to be executed
-      #     in the wrapped environment. If false (the default), blocks are
-      #     replaced by a proc that passes messages back out to the caller and
-      #     executes the block in the caller's environment.
+      # @param arguments [:move,:copy] How to communicate method arguments.
+      # @param results [:move,:copy,:void] How to communicate method return
+      #     values.
+      # @param block_arguments [:move,:copy] How to communicate block arguments.
+      # @param block_results [:move,:copy,:void] How to communicate block
+      #     result values.
+      # @param block_environment [:caller,:wrapped] How to execute blocks, and
+      #     what scope blocks have access to.
       #
       def configure_method(method_name = nil,
-                           move_data: false,
-                           move_arguments: nil,
-                           move_results: nil,
-                           move_block_arguments: nil,
-                           move_block_results: nil,
-                           execute_blocks_in_place: nil)
+                           arguments: nil,
+                           results: nil,
+                           block_arguments: nil,
+                           block_results: nil,
+                           block_environment: nil)
         method_name = method_name.to_sym unless method_name.nil?
         @method_settings[method_name] =
-          MethodSettings.new(move_data: move_data,
-                             move_arguments: move_arguments,
-                             move_results: move_results,
-                             move_block_arguments: move_block_arguments,
-                             move_block_results: move_block_results,
-                             execute_blocks_in_place: execute_blocks_in_place)
+          MethodSettings.new(arguments: arguments,
+                             results: results,
+                             block_arguments: block_arguments,
+                             block_results: block_results,
+                             block_environment: block_environment)
         self
       end
 
@@ -351,23 +374,37 @@ class Ractor
 
       ##
       # @private
-      # Return the method settings keyed by method name. The `nil` key will
-      # contain defaults for method names not explicitly configured. This
-      # hash is a frozen snapshot and cannot be modified.
+      # Resolve the method settings by filling in the defaults for all fields
+      # not explicitly set, and return the final settings keyed by method name.
+      # The `nil` key will contain defaults for method names not explicitly
+      # configured. This hash will be frozen and shareable.
       #
       # @return [Hash{(Symbol,nil)=>MethodSettings}]
       #
-      def method_settings
-        @method_settings.dup.freeze
+      def final_method_settings
+        fallback = MethodSettings.new(arguments: :copy, results: :copy,
+                                      block_arguments: :copy, block_results: :copy,
+                                      block_environment: :caller)
+        defaults = MethodSettings.with_fallback(@method_settings[nil], fallback)
+        results = {nil => defaults}
+        @method_settings.each do |name, settings|
+          next if name.nil?
+          results[name] = MethodSettings.with_fallback(settings, defaults)
+        end
+        results.freeze
       end
 
       ##
       # @private
-      # Create an empty configuration. All settings must be set at least once
-      # before they can be read.
+      # Create an empty configuration.
       #
       def initialize
         @method_settings = {}
+        configure_method(arguments: nil,
+                         results: nil,
+                         block_arguments: nil,
+                         block_results: nil,
+                         block_environment: nil)
       end
     end
 
@@ -377,63 +414,74 @@ class Ractor
     #
     class MethodSettings
       # @private
-      def initialize(move_data: false,
-                     move_arguments: nil,
-                     move_results: nil,
-                     move_block_arguments: nil,
-                     move_block_results: nil,
-                     execute_blocks_in_place: nil)
-        @move_arguments = interpret_setting(move_arguments, move_data)
-        @move_results = interpret_setting(move_results, move_data)
-        @move_block_arguments = interpret_setting(move_block_arguments, move_data)
-        @move_block_results = interpret_setting(move_block_results, move_data)
-        @execute_blocks_in_place = interpret_setting(execute_blocks_in_place, false)
+      def initialize(arguments: nil,
+                     results: nil,
+                     block_arguments: nil,
+                     block_results: nil,
+                     block_environment: nil)
+        unless [nil, :copy, :move].include?(arguments)
+          raise ::ArgumentError, "Unknown `arguments`: #{arguments.inspect} (must be :copy or :move)"
+        end
+        unless [nil, :copy, :move, :void].include?(results)
+          raise ::ArgumentError, "Unknown `results`: #{results.inspect} (must be :copy, :move, or :void)"
+        end
+        unless [nil, :copy, :move].include?(block_arguments)
+          raise ::ArgumentError, "Unknown `block_arguments`: #{block_arguments.inspect} (must be :copy or :move)"
+        end
+        unless [nil, :copy, :move, :void].include?(block_results)
+          raise ::ArgumentError, "Unknown `block_results`: #{block_results.inspect} (must be :copy, :move, or :void)"
+        end
+        unless [nil, :caller, :wrapped].include?(block_environment)
+          raise ::ArgumentError,
+                "Unknown `block_environment`: #{block_environment.inspect} (must be :caller or :wrapped)"
+        end
+        @arguments = arguments
+        @results = results
+        @block_arguments = block_arguments
+        @block_results = block_results
+        @block_environment = block_environment
         freeze
       end
 
       ##
-      # @return [Boolean] Whether to move arguments
+      # @return [:copy,:move] How to communicate method arguments
+      # @return [nil] if not set (will not happen in final settings)
       #
-      def move_arguments?
-        @move_arguments
-      end
+      attr_reader :arguments
 
       ##
-      # @return [Boolean] Whether to move return values
+      # @return [:copy,:move,:void] How to communicate method return values
+      # @return [nil] if not set (will not happen in final settings)
       #
-      def move_results?
-        @move_results
-      end
+      attr_reader :results
 
       ##
-      # @return [Boolean] Whether to move arguments to a block
+      # @return [:copy,:move] How to communicate arguments to a block
+      # @return [nil] if not set (will not happen in final settings)
       #
-      def move_block_arguments?
-        @move_block_arguments
-      end
+      attr_reader :block_arguments
 
       ##
-      # @return [Boolean] Whether to move block results
+      # @return [:copy,:move,:void] How to communicate block results
+      # @return [nil] if not set (will not happen in final settings)
       #
-      def move_block_results?
-        @move_block_results
-      end
+      attr_reader :block_results
 
       ##
-      # @return [Boolean] Whether to call blocks in-place
+      # @return [:caller,:wrapped] What environment blocks execute in
+      # @return [nil] if not set (will not happen in final settings)
       #
-      def execute_blocks_in_place?
-        @execute_blocks_in_place
-      end
+      attr_reader :block_environment
 
-      private
-
-      def interpret_setting(setting, default)
-        if setting.nil?
-          default ? true : false
-        else
-          setting ? true : false
-        end
+      # @private
+      def self.with_fallback(settings, fallback)
+        new(
+          arguments: settings.arguments || fallback.arguments,
+          results: settings.results || fallback.results,
+          block_arguments: settings.block_arguments || fallback.block_arguments,
+          block_results: settings.block_results || fallback.block_results,
+          block_environment: settings.block_environment || fallback.block_environment
+        )
       end
     end
 
@@ -443,7 +491,10 @@ class Ractor
     # If you pass an optional block, a {Ractor::Wrapper::Configuration} object
     # will be yielded to it, allowing additional configuration before the wrapper
     # starts. In particular, per-method configuration must be set in this block.
-    # Block settings override keyword arguments when both are provided.
+    # Block-provided settings override keyword arguments.
+    #
+    # See {Configuration} for more information about the method communication
+    # and block settings.
     #
     # @param object [Object] The non-shareable object to wrap.
     # @param use_current_ractor [boolean] If true, the wrapper is run in a
@@ -452,29 +503,21 @@ class Ractor
     #     cannot be moved or must run in the main Ractor. Can also be set via
     #     the configuration block.
     # @param name [String] A name for this wrapper. Used during logging. Can
-    #     also be set via the configuration block.
+    #     also be set via the configuration block. Defaults to the object_id.
     # @param threads [Integer] The number of worker threads to run.
     #     Defaults to 0, which causes the wrapper to run sequentially without
     #     spawning workers. Can also be set via the configuration block.
-    # @param move_data [boolean] If true, all communication will by default
-    #     move instead of copy arguments and return values. Default is false.
-    #     This setting can be overridden by other `:move_*` settings.
-    # @param move_arguments [boolean] If true, all arguments will be moved
-    #     instead of copied by default. If not set, uses the `:move_data`
-    #     setting.
-    # @param move_results [boolean] If true, return values are moved instead of
-    #     copied by default. If not set, uses the `:move_data` setting.
-    # @param move_block_arguments [boolean] If true, arguments to blocks are
-    #     moved instead of copied by default. If not set, uses the `:move_data`
-    #     setting.
-    # @param move_block_results [boolean] If true, result values from blocks
-    #     are moved instead of copied by default. If not set, uses the
-    #     `:move_data` setting.
-    # @param execute_blocks_in_place [boolean] If true, blocks passed to
-    #     methods are made shareable and passed into the wrapper to be executed
-    #     in the wrapped environment. If false (the default), blocks are
-    #     replaced by a proc that passes messages back out to the caller and
-    #     executes the block in the caller's environment.
+    # @param arguments [:move,:copy] How to communicate method arguments by
+    #     default. If not specified, defaults to `:copy`.
+    # @param results [:move,:copy,:void] How to communicate method return
+    #     values by default. If not specified, defaults to `:copy`.
+    # @param block_arguments [:move,:copy] How to communicate block arguments
+    #     by default. If not specified, defaults to `:copy`.
+    # @param block_results [:move,:copy,:void] How to communicate block result
+    #     values by default. If not specified, defaults to `:copy`.
+    # @param block_environment [:caller,:wrapped] How to execute blocks, and
+    #     what scope blocks have access to. If not specified, defaults to
+    #     `:caller`.
     # @param enable_logging [boolean] Set to true to enable logging. Default
     #     is false. Can also be set via the configuration block.
     # @yield [config] An optional configuration block.
@@ -484,40 +527,37 @@ class Ractor
                    use_current_ractor: false,
                    name: nil,
                    threads: 0,
-                   move_data: false,
-                   move_arguments: nil,
-                   move_results: nil,
-                   move_block_arguments: nil,
-                   move_block_results: nil,
-                   execute_blocks_in_place: nil,
+                   arguments: nil,
+                   results: nil,
+                   block_arguments: nil,
+                   block_results: nil,
+                   block_environment: nil,
                    enable_logging: false)
       raise ::Ractor::MovedError, "cannot wrap a moved object" if ::Ractor::MovedObject === object
 
       config = Configuration.new
-      config.name = name || object_id
+      config.name = name || object_id.to_s
       config.enable_logging = enable_logging
       config.threads = threads
       config.use_current_ractor = use_current_ractor
-      config.configure_method(move_data: move_data,
-                              move_arguments: move_arguments,
-                              move_results: move_results,
-                              move_block_arguments: move_block_arguments,
-                              move_block_results: move_block_results,
-                              execute_blocks_in_place: execute_blocks_in_place)
+      config.configure_method(arguments: arguments,
+                              results: results,
+                              block_arguments: block_arguments,
+                              block_results: block_results,
+                              block_environment: block_environment)
       yield config if block_given?
 
       @name = config.name
       @enable_logging = config.enable_logging
       @threads = config.threads
-      @method_settings = config.method_settings
+      @method_settings = config.final_method_settings
+      @stub = Stub.new(self)
+
       if config.use_current_ractor
         setup_local_server(object)
       else
         setup_isolated_server(object)
       end
-      @stub = Stub.new(self)
-
-      freeze
     end
 
     ##
@@ -595,7 +635,7 @@ class Ractor
                                 reply_port: reply_port)
       maybe_log("Sending method", method_name: method_name, transaction: transaction)
       begin
-        @port.send(message, move: settings.move_arguments?)
+        @port.send(message, move: settings.arguments == :move)
       rescue ::Ractor::ClosedError
         raise StoppedError, "Wrapper has stopped"
       end
@@ -671,13 +711,17 @@ class Ractor
     # case, any calls to this method will raise Ractor::Error.
     #
     # Only one ractor may call this method; any additional calls will fail with
-    # a Ractor::Error.
+    # a Ractor::Wrapper::Error.
     #
     # @return [Object] The original wrapped object
     #
     def recover_object
-      raise ::Ractor::Error, "cannot recover an object from a local wrapper" unless @ractor
-      @ractor.value
+      raise Error, "cannot recover an object from a local wrapper" unless @ractor
+      begin
+        @ractor.value
+      rescue ::Ractor::Error => e
+        raise ::Ractor::Wrapper::Error, e.message, cause: e
+      end
     end
 
     #### private items below ####
@@ -686,7 +730,7 @@ class Ractor
     # @private
     # Message sent to initialize a server.
     #
-    InitMessage = ::Data.define(:object, :enable_logging, :threads)
+    InitMessage = ::Data.define(:object, :stub)
 
     ##
     # @private
@@ -747,10 +791,12 @@ class Ractor
       maybe_log("Starting local server")
       @ractor = nil
       @port = ::Ractor::Port.new
+      freeze
       wrapper_id = object_id
       ::Thread.new do
         ::Thread.current.name = "ractor-wrapper:server:#{wrapper_id}"
         Server.run_local(object: object,
+                         stub: @stub,
                          port: @port,
                          name: name,
                          enable_logging: enable_logging?,
@@ -771,7 +817,9 @@ class Ractor
                             threads: threads)
       end
       @port = @ractor.default_port
-      @port.send(object, move: true)
+      freeze
+      init_message = InitMessage.new(object: object, stub: @stub)
+      @port.send(init_message, move: true)
     end
 
     ##
@@ -787,7 +835,7 @@ class Ractor
     def make_block_arg(settings, &)
       if !block_given?
         nil
-      elsif settings.execute_blocks_in_place?
+      elsif settings.block_environment == :wrapped
         ::Ractor.shareable_proc(&)
       else
         :send_block_message
@@ -801,8 +849,9 @@ class Ractor
       maybe_log("Yielding to block", method_name: method_name, transaction: transaction)
       begin
         block_result = yield(*message.args, **message.kwargs)
+        block_result = nil if settings.block_results == :void
         maybe_log("Sending block result", method_name: method_name, transaction: transaction)
-        message.reply_port.send(ReturnMessage.new(block_result), move: settings.move_block_results?)
+        message.reply_port.send(ReturnMessage.new(block_result), move: settings.block_results == :move)
       rescue ::Exception => e # rubocop:disable Lint/RescueException
         maybe_log("Sending block exception", method_name: method_name, transaction: transaction)
         begin
@@ -847,8 +896,8 @@ class Ractor
       # @private
       # Create and run a server hosted in the current Ractor
       #
-      def self.run_local(object:, port:, name:, enable_logging: false, threads: 0)
-        server = new(isolated: false, object:, port:, name:, enable_logging:, threads:)
+      def self.run_local(object:, stub:, port:, name:, enable_logging: false, threads: 0)
+        server = new(isolated: false, object:, stub:, port:, name:, enable_logging:, threads:)
         server.run
       end
 
@@ -858,14 +907,15 @@ class Ractor
       #
       def self.run_isolated(name:, enable_logging: false, threads: 0)
         port = ::Ractor.current.default_port
-        server = new(isolated: true, object: nil, port:, name:, enable_logging:, threads:)
+        server = new(isolated: true, object: nil, stub: nil, port:, name:, enable_logging:, threads:)
         server.run
       end
 
       # @private
-      def initialize(isolated:, object:, port:, name:, enable_logging:, threads:)
+      def initialize(isolated:, object:, stub:, port:, name:, enable_logging:, threads:)
         @isolated = isolated
         @object = object
+        @stub = stub
         @port = port
         @name = name
         @enable_logging = enable_logging
@@ -900,8 +950,10 @@ class Ractor
       # separate Ractor.
       #
       def receive_remote_object
-        maybe_log("Waiting for remote object")
-        @object = @port.receive
+        maybe_log("Waiting for initialization")
+        init_message = @port.receive
+        @object = init_message.object
+        @stub = init_message.stub
       end
 
       ##
@@ -1155,8 +1207,10 @@ class Ractor
         block = make_block(message)
         maybe_log("Running method", worker_num: worker_num, call_message: message)
         result = @object.__send__(message.method_name, *message.args, **message.kwargs, &block)
+        result = @stub if result.equal?(@object)
+        result = nil if message.settings.results == :void
         maybe_log("Sending return value", worker_num: worker_num, call_message: message)
-        message.reply_port.send(ReturnMessage.new(result), move: message.settings.move_results?)
+        message.reply_port.send(ReturnMessage.new(result), move: message.settings.results == :move)
       rescue ::Exception => e # rubocop:disable Lint/RescueException
         maybe_log("Sending exception", worker_num: worker_num, call_message: message)
         begin
@@ -1185,8 +1239,10 @@ class Ractor
         proc do |*args, **kwargs|
           reply_port = ::Ractor::Port.new
           reply_message = begin
+            args.map! { |arg| arg.equal?(@object) ? @stub : arg }
+            kwargs.transform_values! { |arg| arg.equal?(@object) ? @stub : arg }
             yield_message = YieldMessage.new(args: args, kwargs: kwargs, reply_port: reply_port)
-            message.reply_port.send(yield_message, move: message.settings.move_block_arguments?)
+            message.reply_port.send(yield_message, move: message.settings.block_arguments == :move)
             reply_port.receive
           ensure
             reply_port.close

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -44,4 +44,12 @@ class RemoteObject
     sleep(1)
     arg
   end
+
+  def return_self
+    self
+  end
+
+  def block_args_self(obj1, obj2)
+    yield(obj1, self, kwobj: obj2, kwself: self)
+  end
 end

--- a/test/test_wrapper.rb
+++ b/test/test_wrapper.rb
@@ -28,41 +28,145 @@ describe ::Ractor::Wrapper do
     end
   end
 
-  describe "initialization block" do
+  describe "configuration" do
     after { @wrapper&.async_stop&.join }
 
-    it "yields a Configuration, not the Wrapper itself" do
-      yielded = nil
-      @wrapper = ::Ractor::Wrapper.new(remote) { |config| yielded = config }
-      assert_instance_of(::Ractor::Wrapper::Configuration, yielded)
-      refute_equal(@wrapper, yielded)
-    end
-
-    it "can set name in the block" do
-      @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.name = "myname" }
-      assert_equal("myname", @wrapper.name)
-    end
-
-    it "can set threads in the block" do
-      @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.threads = 2 }
-      assert_equal(2, @wrapper.threads)
-    end
-
-    it "can set use_current_ractor in the block" do
-      @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.use_current_ractor = true }
-      assert(@wrapper.use_current_ractor?)
-    end
-
-    it "block settings override kwargs" do
-      @wrapper = ::Ractor::Wrapper.new(remote, threads: 2) { |config| config.threads = 0 }
+    it "has a known default" do
+      @wrapper = ::Ractor::Wrapper.new(remote)
+      assert_equal(@wrapper.object_id.to_s, @wrapper.name)
+      assert_equal(false, @wrapper.enable_logging?)
       assert_equal(0, @wrapper.threads)
+      assert_equal(false, @wrapper.use_current_ractor?)
+      method_settings = @wrapper.method_settings(:hello)
+      assert_equal(:copy, method_settings.arguments)
+      assert_equal(:copy, method_settings.results)
+      assert_equal(:copy, method_settings.block_arguments)
+      assert_equal(:copy, method_settings.block_results)
+      assert_equal(:caller, method_settings.block_environment)
     end
 
-    it "block can call configure_method" do
-      @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.configure_method(move_arguments: true) }
-      str = "hello".dup
-      @wrapper.call(:echo_args, str)
-      assert_raises(::Ractor::MovedError) { str.to_s }
+    describe "via keyword args" do
+      it "can set name" do
+        @wrapper = ::Ractor::Wrapper.new(remote, name: "myname")
+        assert_equal("myname", @wrapper.name)
+      end
+
+      it "can set use_current_ractor" do
+        @wrapper = ::Ractor::Wrapper.new(remote, use_current_ractor: true)
+        assert_equal(true, @wrapper.use_current_ractor?)
+      end
+
+      it "can set threads" do
+        @wrapper = ::Ractor::Wrapper.new(remote, threads: 3)
+        assert_equal(3, @wrapper.threads)
+      end
+
+      it "can set default arguments" do
+        @wrapper = ::Ractor::Wrapper.new(remote, arguments: :move)
+        method_settings = @wrapper.method_settings(:hello)
+        assert_equal(:move, method_settings.arguments)
+      end
+
+      it "can set default results" do
+        @wrapper = ::Ractor::Wrapper.new(remote, results: :void)
+        method_settings = @wrapper.method_settings(:hello)
+        assert_equal(:void, method_settings.results)
+      end
+
+      it "can set default block arguments" do
+        @wrapper = ::Ractor::Wrapper.new(remote, block_arguments: :move)
+        method_settings = @wrapper.method_settings(:hello)
+        assert_equal(:move, method_settings.block_arguments)
+      end
+
+      it "can set default block results" do
+        @wrapper = ::Ractor::Wrapper.new(remote, block_results: :void)
+        method_settings = @wrapper.method_settings(:hello)
+        assert_equal(:void, method_settings.block_results)
+      end
+
+      it "can set default block environment" do
+        @wrapper = ::Ractor::Wrapper.new(remote, block_environment: :wrapped)
+        method_settings = @wrapper.method_settings(:hello)
+        assert_equal(:wrapped, method_settings.block_environment)
+      end
+
+      it "validates default arguments" do
+        assert_raises(::ArgumentError) do
+          @wrapper = ::Ractor::Wrapper.new(remote, arguments: :toe)
+        end
+      end
+
+      it "validates default results" do
+        assert_raises(::ArgumentError) do
+          @wrapper = ::Ractor::Wrapper.new(remote, results: :salchow)
+        end
+      end
+
+      it "validates default block_arguments" do
+        assert_raises(::ArgumentError) do
+          @wrapper = ::Ractor::Wrapper.new(remote, block_arguments: :loop)
+        end
+      end
+
+      it "validates default block_results" do
+        assert_raises(::ArgumentError) do
+          @wrapper = ::Ractor::Wrapper.new(remote, block_results: :flip)
+        end
+      end
+
+      it "validates default block_environment" do
+        assert_raises(::ArgumentError) do
+          @wrapper = ::Ractor::Wrapper.new(remote, block_environment: :axel)
+        end
+      end
+    end
+
+    describe "via initialization block" do
+      it "yields a Configuration" do
+        yielded = nil
+        @wrapper = ::Ractor::Wrapper.new(remote) { |config| yielded = config }
+        assert_instance_of(::Ractor::Wrapper::Configuration, yielded)
+      end
+
+      it "can set name" do
+        @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.name = "myname" }
+        assert_equal("myname", @wrapper.name)
+      end
+
+      it "can set threads" do
+        @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.threads = 2 }
+        assert_equal(2, @wrapper.threads)
+      end
+
+      it "can set use_current_ractor" do
+        @wrapper = ::Ractor::Wrapper.new(remote) { |config| config.use_current_ractor = true }
+        assert_equal(true, @wrapper.use_current_ractor?)
+      end
+
+      it "overrides kwargs" do
+        @wrapper = ::Ractor::Wrapper.new(remote, threads: 2) { |config| config.threads = 3 }
+        assert_equal(3, @wrapper.threads)
+      end
+
+      it "can call configure_method to override default method config" do
+        @wrapper = ::Ractor::Wrapper.new(remote) do |config|
+          config.configure_method(results: :move)
+          config.configure_method(:hello, results: :void)
+        end
+        hello_method_settings = @wrapper.method_settings(:hello)
+        assert_equal(:void, hello_method_settings.results)
+        bye_method_settings = @wrapper.method_settings(:bye)
+        assert_equal(:move, bye_method_settings.results)
+      end
+
+      it "validates arguments to configure_method" do
+        assert_raises(::ArgumentError) do
+          @wrapper = ::Ractor::Wrapper.new(remote) do |config|
+            config.configure_method(block_environment: :axel)
+          end
+        end
+      end
     end
   end
 
@@ -110,6 +214,27 @@ describe ::Ractor::Wrapper do
         wrapper.async_stop
         recovered = wrapper.recover_object
         assert_equal("[], {}", recovered.echo_args)
+      end
+
+      it "allows recovery from another ractor" do
+        wrapper.async_stop
+        ractor2 = ::Ractor.new(wrapper) do |wrap|
+          recovered = wrap.recover_object
+          recovered.echo_args
+        end
+        assert_equal("[], {}", ractor2.value)
+      end
+
+      it "does not allow recovery from another ractor if already recovered" do
+        wrapper.async_stop
+        wrapper.recover_object
+        ractor2 = ::Ractor.new(wrapper) do |wrap|
+          wrap.recover_object
+          ""
+        rescue ::StandardError => e
+          e.class.name
+        end
+        assert_equal("Ractor::Wrapper::Error", ractor2.value)
       end
     end
 
@@ -179,7 +304,7 @@ describe ::Ractor::Wrapper do
         assert_equal("Whoops", exception.message)
       end
 
-      it "yields to a local block" do
+      it "yields to a caller-environment block" do
         local_var = false
         result = wrapper.call(:run_block, 1, 2, a: "b", c: "d") do |one, two, a:, c:|
           local_var = true
@@ -189,12 +314,24 @@ describe ::Ractor::Wrapper do
         assert_equal(true, local_var)
       end
 
-      it "yields to an in-place block" do
-        wrapper(execute_blocks_in_place: true)
+      it "yields to a wrapped-environment block" do
+        wrapper(block_environment: :wrapped)
         result = wrapper.call(:run_block, 1, 2, a: "b", c: "d") do |one, two, a:, c:|
           "result #{one} #{two} #{a} #{c} #{inspect}"
         end
         assert_equal("result 1 2 b d nil", result)
+      end
+
+      it "does not allow a wrapped-environment block to access the caller environment" do
+        local_var = false
+        wrapper(block_environment: :wrapped)
+        assert_raises(::ArgumentError) do
+          wrapper.call(:run_block, 1, 2, a: "b", c: "d") do |one, two, a:, c:|
+            local_var = true
+            "result #{one} #{two} #{a} #{c}"
+          end
+        end
+        assert_equal(false, local_var)
       end
     end
 
@@ -213,25 +350,11 @@ describe ::Ractor::Wrapper do
         str.to_s # Would fail if str was moved
       end
 
-      it "moves arguments when move_arguments is set to true" do
-        wrapper(move_arguments: true)
+      it "moves arguments when arguments is set to :move" do
+        wrapper(arguments: :move)
         str = "hello".dup
         wrapper.call(:echo_args, str)
         assert_raises(::Ractor::MovedError) { str.to_s }
-      end
-
-      it "moves arguments when move_data is set to true" do
-        wrapper(move_data: true)
-        str = "hello".dup
-        wrapper.call(:echo_args, str)
-        assert_raises(::Ractor::MovedError) { str.to_s }
-      end
-
-      it "honors move_arguments over move_data" do
-        wrapper(move_data: true, move_arguments: false)
-        str = "hello".dup
-        wrapper.call(:echo_args, str)
-        str.to_s # Would fail if str was moved
       end
 
       it "copies return values by default" do
@@ -239,22 +362,16 @@ describe ::Ractor::Wrapper do
         refute_equal(obj.object_id, id)
       end
 
-      it "moves return values when move_results is set to true" do
-        wrapper(move_results: true)
+      it "moves return values when results is set to :move" do
+        wrapper(results: :move)
         obj, id = wrapper.call(:object_and_id, "hello".dup)
         assert_equal(obj.object_id, id)
       end
 
-      it "moves return values when move_data is set to true" do
-        wrapper(move_data: true)
-        obj, id = wrapper.call(:object_and_id, "hello".dup)
-        assert_equal(obj.object_id, id)
-      end
-
-      it "honors move_results over move_data" do
-        wrapper(move_data: true, move_results: false)
-        obj, id = wrapper.call(:object_and_id, "hello".dup)
-        refute_equal(obj.object_id, id)
+      it "suppresses return values when results is set to :void" do
+        wrapper(results: :void)
+        result = wrapper.call(:object_and_id, "hello".dup)
+        assert_nil(result)
       end
 
       it "copies block arguments by default" do
@@ -264,32 +381,16 @@ describe ::Ractor::Wrapper do
         refute_equal(orig_id, arg_id)
       end
 
-      it "moves block arguments when move_block_arguments is set" do
-        wrapper(move_block_arguments: true)
+      it "moves block arguments when block_arguments is :move" do
+        wrapper(block_arguments: :move)
         arg_id, orig_id = wrapper.call(:run_block_with_id, "hello".dup) do |str, str_id|
           [str.object_id, str_id]
         end
         assert_equal(orig_id, arg_id)
-      end
-
-      it "moves block arguments when move_data is set" do
-        wrapper(move_data: true)
-        arg_id, orig_id = wrapper.call(:run_block_with_id, "hello".dup) do |str, str_id|
-          [str.object_id, str_id]
-        end
-        assert_equal(orig_id, arg_id)
-      end
-
-      it "honors move_block_arguments over move_data" do
-        wrapper(move_data: true, move_block_arguments: false)
-        arg_id, orig_id = wrapper.call(:run_block_with_id, "hello".dup) do |str, str_id|
-          [str.object_id, str_id]
-        end
-        refute_equal(orig_id, arg_id)
       end
 
       it "copies block results by default" do
-        wrapper(move_results: true)
+        wrapper(results: :move)
         obj, id = wrapper.call(:run_block) do
           str = "hello".dup
           [str, str.object_id]
@@ -297,8 +398,8 @@ describe ::Ractor::Wrapper do
         refute_equal(obj.object_id, id)
       end
 
-      it "moves block results when move_block_results is set" do
-        wrapper(move_results: true, move_block_results: true)
+      it "moves block results when block_results is :move" do
+        wrapper(results: :move, block_results: :move)
         obj, id = wrapper.call(:run_block) do
           str = "hello".dup
           [str, str.object_id]
@@ -306,22 +407,13 @@ describe ::Ractor::Wrapper do
         assert_equal(obj.object_id, id)
       end
 
-      it "moves block results when move_data is set" do
-        wrapper(move_data: true)
-        obj, id = wrapper.call(:run_block) do
+      it "suppresses block results when block_results is :void" do
+        wrapper(results: :move, block_results: :void)
+        result = wrapper.call(:run_block) do
           str = "hello".dup
           [str, str.object_id]
         end
-        assert_equal(obj.object_id, id)
-      end
-
-      it "honors move_block_results over move_data" do
-        wrapper(move_data: true, move_block_results: false)
-        obj, id = wrapper.call(:run_block) do
-          str = "hello".dup
-          [str, str.object_id]
-        end
-        refute_equal(obj.object_id, id)
+        assert_nil(result)
       end
     end
 
@@ -358,6 +450,21 @@ describe ::Ractor::Wrapper do
       it "converts respond_to" do
         assert(wrapper.stub.respond_to?(:echo_args))
         refute(wrapper.stub.respond_to?(:nonexistent_method))
+      end
+
+      it "returns stubs instead of wrapped object" do
+        returned_self = wrapper.stub.return_self
+        result = returned_self.echo_args
+        assert_equal("[], {}", result)
+      end
+
+      it "yields stubs instead of wrapped object" do
+        wrapper.stub.block_args_self("hello", "ruby") do |obj1, obj2, kwobj:, kwself:|
+          assert_equal("hello", obj1)
+          assert_kind_of(::Ractor::Wrapper::Stub, obj2)
+          assert_equal("ruby", kwobj)
+          assert_kind_of(::Ractor::Wrapper::Stub, kwself)
+        end
       end
     end
   end
@@ -442,7 +549,7 @@ describe ::Ractor::Wrapper do
     end
 
     [
-      {desc: "isolated threaded wrapper", opts: {threads: 1, enable_logging: true}},
+      {desc: "isolated threaded wrapper", opts: {threads: 1}},
       {desc: "local threaded wrapper", opts: {use_current_ractor: true, threads: 1}},
     ].each do |config|
       describe config[:desc] do


### PR DESCRIPTION
feat!: Method configuration interface now uses symbolic settings values instead of booleans for more flexibility
feat: Support for suppressing return values for methods and blocks that unintentionally return something they shouldn't
fix: Methods that return or yield self return/yield the stub instead
fix: The recover_object method now raises Ractor::Wrapper::Error if recovery failed

