### PR TITLE
release: Release ractor-wrapper 0.4.0 (was 0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Release History
 
+### v0.4.0 / 2026-03-30
+
+* BREAKING CHANGE: Raises `Ractor::Wrapper::StoppedError` instead of `Ractor::ClosedError` if a method is called via the wrapper after the wrapper has stopped
+* BREAKING CHANGE: `Wrapper#join` now returns normally rather than raising, if an isolated wrapper terminated due to a crash
+* BREAKING CHANGE: Method configuration interface now uses symbolic settings values instead of booleans for more flexibility
+* ADDED: Use a separate Ractor::Wrapper::Configuration class for block-based initialization
+* ADDED: Method configuration interface now uses symbolic settings values instead of booleans for more flexibility
+* ADDED: Support for suppressing return values for methods and blocks that unintentionally return something they shouldn't
+* FIXED: Raises `Ractor::Wrapper::StoppedError` instead of `Ractor::ClosedError` if a method is called via the wrapper after the wrapper has stopped
+* FIXED: Method calls raise `Ractor::Wrapper::CrashedError` instead of hanging if the wrapper crashes during handling
+* FIXED: `Wrapper#join` no longer hangs if a local wrapper crashes, but returns to indicate that the wrapper has stopped (albeit non-normally)
+* FIXED: `Wrapper#join` now returns normally rather than raising, if an isolated wrapper terminated due to a crash
+* FIXED: Internal cleanup is more robust if a crash occurs in the wrapper
+* FIXED: Prevented port leaks if a method call send or a block yield send fails
+* FIXED: Methods that return or yield self return/yield the stub instead
+* FIXED: The recover_object method now raises Ractor::Wrapper::Error if recovery failed
+* DOCS: Updates to README
+
 ### v0.3.0 / 2026-01-05
 
 This is a major update, and the library, while still experimental, is finally somewhat usable. The examples in the README now actually work!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,19 @@
 
 ### v0.4.0 / 2026-03-30
 
+This release includes two major changes: it greatly improves robustness in the case of server crashes, and it reworks the method call configuration interface. This involves several breaking changes, and I expect the interface will continue to be a bit unstable for now as I'm working through use cases and edge cases. The README has also been expanded to include more information on the configuration options and the known issues.
+
+* ADDED: Uses a separate `Ractor::Wrapper::Configuration` class for block-based initialization. Removed the configuration mutation methods from `Ractor::Wrapper` itself.
+* BREAKING CHANGE: The method configuration interface now uses symbolic settings values instead of booleans for more flexibility
+* ADDED: Support for suppressing return values for methods and blocks that unintentionally return something they shouldn't
 * BREAKING CHANGE: Raises `Ractor::Wrapper::StoppedError` instead of `Ractor::ClosedError` if a method is called via the wrapper after the wrapper has stopped
 * BREAKING CHANGE: `Wrapper#join` now returns normally rather than raising, if an isolated wrapper terminated due to a crash
-* BREAKING CHANGE: Method configuration interface now uses symbolic settings values instead of booleans for more flexibility
-* ADDED: Use a separate Ractor::Wrapper::Configuration class for block-based initialization
-* ADDED: Method configuration interface now uses symbolic settings values instead of booleans for more flexibility
-* ADDED: Support for suppressing return values for methods and blocks that unintentionally return something they shouldn't
-* FIXED: Raises `Ractor::Wrapper::StoppedError` instead of `Ractor::ClosedError` if a method is called via the wrapper after the wrapper has stopped
-* FIXED: Method calls raise `Ractor::Wrapper::CrashedError` instead of hanging if the wrapper crashes during handling
-* FIXED: `Wrapper#join` no longer hangs if a local wrapper crashes, but returns to indicate that the wrapper has stopped (albeit non-normally)
-* FIXED: `Wrapper#join` now returns normally rather than raising, if an isolated wrapper terminated due to a crash
+* BREAKING FIX: `Wrapper#join` no longer hangs if a local wrapper crashes, but returns to indicate that the wrapper has stopped (albeit non-normally)
 * FIXED: Internal cleanup is more robust if a crash occurs in the wrapper
+* FIXED: Method calls raise `Ractor::Wrapper::CrashedError` instead of hanging if the wrapper crashes during handling
 * FIXED: Prevented port leaks if a method call send or a block yield send fails
 * FIXED: Methods that return or yield self return/yield the stub instead
-* FIXED: The recover_object method now raises Ractor::Wrapper::Error if recovery failed
+* FIXED: The `recover_object` method now raises `Ractor::Wrapper::Error` if recovery failed
 * DOCS: Updates to README
 
 ### v0.3.0 / 2026-01-05

--- a/lib/ractor/wrapper/version.rb
+++ b/lib/ractor/wrapper/version.rb
@@ -7,6 +7,6 @@ class Ractor
     #
     # @return [String]
     #
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **ractor-wrapper 0.4.0** (was 0.3.0)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## ractor-wrapper

 *  BREAKING CHANGE: Raises `Ractor::Wrapper::StoppedError` instead of `Ractor::ClosedError` if a method is called via the wrapper after the wrapper has stopped
 *  BREAKING CHANGE: `Wrapper#join` now returns normally rather than raising, if an isolated wrapper terminated due to a crash
 *  BREAKING CHANGE: Method configuration interface now uses symbolic settings values instead of booleans for more flexibility
 *  ADDED: Use a separate Ractor::Wrapper::Configuration class for block-based initialization
 *  ADDED: Method configuration interface now uses symbolic settings values instead of booleans for more flexibility
 *  ADDED: Support for suppressing return values for methods and blocks that unintentionally return something they shouldn't
 *  FIXED: Raises `Ractor::Wrapper::StoppedError` instead of `Ractor::ClosedError` if a method is called via the wrapper after the wrapper has stopped
 *  FIXED: Method calls raise `Ractor::Wrapper::CrashedError` instead of hanging if the wrapper crashes during handling
 *  FIXED: `Wrapper#join` no longer hangs if a local wrapper crashes, but returns to indicate that the wrapper has stopped (albeit non-normally)
 *  FIXED: `Wrapper#join` now returns normally rather than raising, if an isolated wrapper terminated due to a crash
 *  FIXED: Internal cleanup is more robust if a crash occurs in the wrapper
 *  FIXED: Prevented port leaks if a method call send or a block yield send fails
 *  FIXED: Methods that return or yield self return/yield the stub instead
 *  FIXED: The recover_object method now raises Ractor::Wrapper::Error if recovery failed
 *  DOCS: Updates to README

----

```
# release_metadata DO NOT REMOVE OR MODIFY
{
  "requested_components": {
    "ractor-wrapper": null
  },
  "request_sha": "9a51b9128f7590b51f61e14620ab00b978fec85d"
}
```
